### PR TITLE
Update branding site layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,23 +4,105 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Raja Sekhar Medindrao</title>
-    <link rel="stylesheet" href="styles/style.css">
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+            background-color: #fff;
+            color: #111;
+            line-height: 1.6;
+        }
+        .container {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            padding: 2rem;
+            gap: 2rem;
+        }
+        .card, .content {
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 2rem;
+        }
+        .card {
+            flex: 1 1 250px;
+            max-width: 320px;
+            text-align: center;
+        }
+        .profile img {
+            width: 180px;
+            height: 180px;
+            border-radius: 50%;
+            object-fit: cover;
+            margin-bottom: 1rem;
+        }
+        .tagline {
+            font-size: 0.95rem;
+            color: #555;
+        }
+        .content {
+            flex: 2 1 300px;
+            max-width: 500px;
+        }
+        .icon-links {
+            display: flex;
+            gap: 1rem;
+            margin-top: 1.5rem;
+        }
+        .icon {
+            color: #007BFF;
+            text-decoration: none;
+        }
+        .icon svg {
+            width: 28px;
+            height: 28px;
+            fill: currentColor;
+        }
+        .icon:hover {
+            color: #0056b3;
+        }
+        footer {
+            text-align: center;
+            padding: 1rem;
+            background-color: #f5f5f5;
+            font-size: 0.85rem;
+        }
+        @media (max-width: 768px) {
+            .container { flex-direction: column; }
+            .card { margin-bottom: 2rem; }
+        }
+    </style>
 </head>
 <body>
     <main class="container">
         <section class="card">
             <div class="profile">
-                <img src="profile.jpg" alt="Profile picture placeholder">
+                <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/..." alt="Profile picture">
                 <h1>Raja Sekhar Medindrao</h1>
-                <p class="tagline">MBA Candidate | Strategy & Technology | Ex-Salesforce PM | Ex-F5 Engineer</p>
+                <p class="tagline">MBA Candidate | Strategy &amp; Technology | Ex-Salesforce PM | Ex-F5 Engineer</p>
             </div>
         </section>
         <section class="content">
             <h2>Hello</h2>
             <p>I'm a Columbia MBA passionate about solving complex problems at the intersection of business and technology.</p>
             <div class="icon-links">
-                <a class="icon" href="mailto:rajsekhar731@gmail.com" aria-label="Email">📧</a>
-                <a class="icon" href="https://www.linkedin.com/in/raja-sekhar-medindrao-62730915a/" aria-label="LinkedIn">🔗</a>
+                <a class="icon" href="mailto:rajsekhar731@gmail.com" aria-label="Email">
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <rect x="2" y="4" width="20" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2"/>
+                        <polyline points="2,6 12,13 22,6" fill="none" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                </a>
+                <a class="icon" href="https://www.linkedin.com/in/raja-sekhar-medindrao-62730915a/" aria-label="LinkedIn">
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <rect x="2" y="2" width="20" height="20" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2"/>
+                        <path d="M6 9h3v9H6zM8 7a1.5 1.5 0 110-3 1.5 1.5 0 010 3zM11 9h3v1.5a3 3 0 016 0V18h-3v-6a1.5 1.5 0 00-3 0v6h-3V9z" fill="currentColor"/>
+                    </svg>
+                </a>
             </div>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- inline CSS for self-contained HTML
- add flexbox card layout and contact icons
- use base64 inline profile image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847b33090f8832e8efcf2b52a7d0152